### PR TITLE
Fix project description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "flit_core.buildapi"
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-systemcoupling-core"
 version = "0.1.dev0"
-description = "A Python wrapper for Ansys MAPDL."
+description = "A Python wrapper for Ansys System Coupling."
 readme = "README.rst"
 requires-python = ">=3.7"
 license = {file = "LICENSE"}


### PR DESCRIPTION
Fix project description, which referred to MAPDL rather than System Coupling.