### PR TITLE
Enable coverage upload

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 # Omit generated API code as coverage is not realistic
-omit = */ansys/systemcoupling/core/adaptor/api_*
+omit = */ansys/systemcoupling/core/adaptor/api_*/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+# Omit generated API code as coverage is not realistic
+omit = */ansys/systemcoupling/core/adaptor/api_*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,9 +142,8 @@ jobs:
         env:
           SYC_IMAGE_TAG: v23.1.0
 
-      # Codecov not available until we are public
-      #- name: Upload coverage to Codecov
-      #  uses: codecov/codecov-action@v2
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2
 
       - name: Upload test coverage
         uses: actions/upload-artifact@v3

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,7 @@
 PySystemCoupling
 ================
-.. TODO : add codecov badge once public
 
-|pyansys| |GH-CI| |MIT| |black|
+|pyansys| |GH-CI| |codecov| |MIT| |black|
 
 .. |pyansys| image:: https://img.shields.io/badge/Py-Ansys-ffc107.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAIAAACQkWg2AAABDklEQVQ4jWNgoDfg5mD8vE7q/3bpVyskbW0sMRUwofHD7Dh5OBkZGBgW7/3W2tZpa2tLQEOyOzeEsfumlK2tbVpaGj4N6jIs1lpsDAwMJ278sveMY2BgCA0NFRISwqkhyQ1q/Nyd3zg4OBgYGNjZ2ePi4rB5loGBhZnhxTLJ/9ulv26Q4uVk1NXV/f///////69du4Zdg78lx//t0v+3S88rFISInD59GqIH2esIJ8G9O2/XVwhjzpw5EAam1xkkBJn/bJX+v1365hxxuCAfH9+3b9/+////48cPuNehNsS7cDEzMTAwMMzb+Q2u4dOnT2vWrMHu9ZtzxP9vl/69RVpCkBlZ3N7enoDXBwEAAA+YYitOilMVAAAAAElFTkSuQmCC
    :target: https://docs.pyansys.com/

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,7 +8,7 @@ coverage:
     project:
       default:
         # basic
-        target: 95%
+        target: 85%
         threshold: 10%
         # advanced
         if_not_found: success

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 comment:
   layout: "diff"
   behavior: default
+  require_changes: true # Post coverage comment only if coverage changes
 
 coverage:
   status:
@@ -20,4 +21,3 @@ coverage:
         if_not_found: success
         if_ci_failed: error
         if_no_uploads: error
-       


### PR DESCRIPTION
Uncomment coverage upload action now that we are public

Exclude the generated API code as it comprises mechanical wrapping of data model and commands. Coverage report is misleading and unrealistic for these files.